### PR TITLE
 Bug fix for invalid unraid template port numbers

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,9 +38,9 @@ opt_param_usage_include_ports: true
 opt_param_ports:
   - { external_port: "27031-27036", internal_port: "27031-27036/udp", port_desc: "Steam Remote Play Ports (UDP)." }
   - { external_port: "27031-27036", internal_port: "27031-27036", port_desc: "Steam Remote Play Ports (TCP)." }
-  - { external_port: "47984-47990:47984-47990", internal_port: "47984-47990:47984-47990/tcp", port_desc: "Sunshine Ports (TCP)." }
+  - { external_port: "47984-47990", internal_port: "47984-47990", port_desc: "Sunshine Ports (TCP)." }
   - { external_port: "48010:48010", internal_port: "48010:48010", port_desc: "Sunshine Ports (TCP)." }
-  - { external_port: "47998-48000:47998-48000", internal_port: "47998-48000:47998-48000/udp", port_desc: "Sunshine Ports (UDP)." }
+  - { external_port: "47998-48000", internal_port: "47998-48000/udp", port_desc: "Sunshine Ports (UDP)." }
 custom_params:
   - { name: "shm-size", name_compose: "shm_size", value: "1gb",desc: "This is needed for the steam browser to function properly." }
 security_opt_param: true


### PR DESCRIPTION
Seems like the ports were accidentally duplicated causing issues on unraid template.

Most likely a copy pasta mistake, this should resolve that...? 

Please review

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ x] I have read the [contributing](https://github.com/linuxserver/docker-steamos/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Corrected the port numbers for the unraid template

## Benefits of this PR and context:
The current template for unraid is errors out when attempting to install because of the invalid port configuration...

## How Has This Been Tested?
It hasn't, so please feel free to correct or implemented yourself....

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://discord.com/channels/354974912613449730/1138483406716539021/1141415537793061016