### PR TITLE
Add in disallow resizing of kasm window

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ services:
       - HOST_IP=192.168.100.10 #optional
       - STARTUP=KDE #optional
       - RESOLUTION=1920x1080 #optional
-      - NO_KASM_RESIZE=1 #optional
+      - DO_NOT_RESIZE_KASM=1 #optional
     volumes:
       - /path/to/config:/config
       - /dev/input:/dev/input #optional
@@ -188,7 +188,7 @@ docker run -d \
   -e HOST_IP=192.168.100.10 `#optional` \
   -e STARTUP=KDE `#optional` \
   -e RESOLUTION=1920x1080 `#optional` \
-  -e NO_KASM_RESIZE=1 `#optional` \
+  -e DO_NOT_RESIZE_KASM=1 `#optional` \
   -p 3000:3000 \
   -p 3001:3001 \
   -p 27031-27036:27031-27036/udp `#optional` \
@@ -226,6 +226,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e HOST_IP=192.168.100.10` | Specify the IP of the host, needed for LAN Remote Play. |
 | `-e STARTUP=KDE` | KDE to boot into desktop mode, BIGPICTURE to boot into gamescope. |
 | `-e RESOLUTION=1920x1080` | When booting into BIGPICTURE mode the screen resolution will be bound to this value. |
+| `-e DO_NOT_RESIZE_KASM=true` | This prohibits the kasm client from resizing the window when opened in a webpage. |
 | `-v /config` | Users home directory in the container, stores all files and games. |
 | `-v /dev/input` | Optional for gamepad support. *Only working for Steam Remote Play |
 | `-v /run/udev/data` | Optional for gamepad support. *Only working for Steam Remote Play |

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ services:
       - HOST_IP=192.168.100.10 #optional
       - STARTUP=KDE #optional
       - RESOLUTION=1920x1080 #optional
+      - NO_KASM_RESIZE=1 #optional
     volumes:
       - /path/to/config:/config
       - /dev/input:/dev/input #optional
@@ -187,6 +188,7 @@ docker run -d \
   -e HOST_IP=192.168.100.10 `#optional` \
   -e STARTUP=KDE `#optional` \
   -e RESOLUTION=1920x1080 `#optional` \
+  -e NO_KASM_RESIZE=1 `#optional` \
   -p 3000:3000 \
   -p 3001:3001 \
   -p 27031-27036:27031-27036/udp `#optional` \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -25,6 +25,8 @@ opt_param_env_vars:
   - {env_var: "HOST_IP", env_value: "192.168.100.10", desc: "Specify the IP of the host, needed for LAN Remote Play."}
   - {env_var: "STARTUP", env_value: "KDE", desc: "KDE to boot into desktop mode, BIGPICTURE to boot into gamescope."}
   - {env_var: "RESOLUTION", env_value: "1920x1080", desc: "When booting into BIGPICTURE mode the screen resolution will be bound to this value."}
+  - {env_var: "DO_NOT_RESIZE_KASM", env_value: "true", desc: "This prohibits the kasm client from resizing the window when opened in a webpage."}
+
 param_usage_include_vols: true
 param_volumes:
   - {vol_path: "/config", vol_host_path: "/path/to/config", desc: "Users home directory in the container, stores all files and games."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -13,6 +13,11 @@ if [ -z ${RESOLUTION+x} ]; then
   RESOLUTION="1920x1080"
 fi
 
+# Disallow Kasm resizing
+if [ -z ${DO_NOT_RESIZE_KASM+x} ]; then
+  SETTING_RESIZE="-AcceptSetDesktopResolution false"
+fi
+
 exec s6-setuidgid abc \
   /usr/local/bin/Xvnc $DISPLAY \
     ${HW3D} \
@@ -24,8 +29,10 @@ exec s6-setuidgid abc \
     -http-header Cross-Origin-Embedder-Policy=require-corp \
     -http-header Cross-Origin-Opener-Policy=same-origin \
     -geometry ${RESOLUTION} \
+    ${SETTING_RESIZE} \
     -sslOnly 0 \
     -RectThreads 0 \
     -websocketPort 6901 \
     -interface 0.0.0.0 \
     -Log *:stdout:10
+    

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -14,8 +14,8 @@ if [ -z ${RESOLUTION+x} ]; then
 fi
 
 # Disallow Kasm resizing
-if [ -z ${DO_NOT_RESIZE_KASM+x} ]; then
-  SETTING_RESIZE="-AcceptSetDesktopResolution false"
+if [ ${DO_NOT_RESIZE_KASM+x} ]; then
+  SETTING_RESIZE="-AcceptSetDesktopSize false"
 fi
 
 exec s6-setuidgid abc \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ x ] I have read the [contributing](https://github.com/linuxserver/docker-steamos/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This change adds a variable to the docker image to disallow resizing of the kasm window. This is intended to be used in conjunction with sunshine to not resize when client is connected.

## Benefits of this PR and context:
Improve user experience when using the image by disallowing the resizing of the xwindow if a web client connects. 

## How Has This Been Tested?
Copied my fork and ran the following docker commands:
```shell
docker buildx build -t tv-steamos .
docker run -p 12345:3000 -e resolution=1920x1080 --rm tv-steamos
docker run -p 12345:3000 -e resolution=1920x1080 -e DO_NOT_RESIZE_KASM=true --rm tv-steamos
```


## Source / References:
I tested this on my computer, need to pull this image and test. That's a next week thing: - tested
https://github.com/T2theV/ESDE-Docker/blob/fix-desktop-resolution/test.dockerfile
https://github.com/T2theV/ESDE-Docker/blob/fix-desktop-resolution/tim.runhttps://kasmweb.com/kasmvnc/docs/1.0.0/man/Xvnc.html#parameters

